### PR TITLE
Añade tests (scaffolding)

### DIFF
--- a/encliticos/test.py
+++ b/encliticos/test.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+import unittest
+from .word import Word
+
+
+class TestEncliticos(unittest.TestCase):
+  """
+  Aquí aparecen casos de uso de enclíticos para comprobar que el
+  código se está comportando como debe.
+  """
+  # TODO (lingüistas): Añadir los tests que se consideren adecuados
+
+  def test_encliticos(self):
+      data = Word("diselo").analyze_word()
+      self.assertEqual(data, '<lo que tenga que devolver>')
+
+  def test_leismos(self):
+      pass
+
+  def test_laismos(self):
+      pass
+
+  def test_loismos(self):
+      pass
+
+
+
+
+class TestConnection(unittest.TestCase):
+  """
+  En esta clase se definen una serie de tests para confirmar que las
+  APIs de Apicultur están disponibles, que el ACCESS_TOKEN introducido
+  tiene acceso a ellas y que algunas llamadas de ejemplo devuelven
+  valores válidos.
+  """
+
+  @classmethod
+  def setUp(cls):
+    from apicultur.utils import ApiculturRateLimitSafe
+    from secret import ACCESS_TOKEN
+    cls.api = ApiculturRateLimitSafe(ACCESS_TOKEN)
+
+  def test_silabeame(self):
+    data = self.api.silabeame(word=u"perro")
+    self.assertEqual(data[u'palabraSilabeada'], u'pe=rro')
+    self.assertEqual(data[u'silabaTonica'], u'pe')
+    self.assertEqual(data[u'numeroSilabas'], 2)
+    self.assertEqual(data[u'posSilabaTonica'], 2)
+
+  def test_lematiza2(self):
+    data = self.api.lematiza2(word=u"meses")
+    self.assertEqual(data[u'palabra'], u'meses')
+    lemas = data[u'lemas']
+    self.assertEqual(len(lemas), 2)
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
He añadido un archivo para incluir tests, los tests suelen ayudar mucho a organizar el código. Al principio puede parecer un esfuerzo extra innecesario, pero a la larga se agradecen.

Básicamente deberás ejecutarlos con:

```
python -m encliticos.test
```

Desde el directorio raíz, la llamada con `-m` le indica a python la ruta del mismo modo que cuando se hace un `from paquete.archivo import whatever`.

---

Escribir tests es muy fácil, casi siempre se va a utilizar el `self.assertEqual(valor1, valor2, 'mensaje en caso de error')` porque la gente suele probar lo que hace el código y se olvida de probar lo que no hace (que también es muy importante). He incluído un ejemplo más abajo donde pruebo las llamadas a las APIs para comprobar que los valores que me devuelve en dos casos básicos son los que espero.

Respecto a probar los enclíticos, no he querido tocar el código para que vayamos haciéndolo poco a poco entre tú/ambos/todos.

Yo perseguiría un primer objetivo:
- **Separar la funcionalidad de los mensajes al usuario**, es decir, dentro del paquete "encliticos" no debería haber ningún `print`, es el código que llama el que debería informar al usuario según los resultados que le ofrece el paquete. De este modo el código ejecuta su funcionalidad y es quien lo llama el que puede decidir qué hacer con los resultados: mostrarlos por la terminal, sacarlos en una interfaz gráfica, **construir unos tests**,...
